### PR TITLE
Add product title lookup from barcodelookup.com

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,9 @@ description = "Taking UPCs, translating them, and making a database of the resul
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "beautifulsoup4>=4.13.4",
     "click>=8.0.0",
+    "httpx>=0.28.1",
 ]
 authors = [
     {name = "Philip James", email = "phildini@phildini.net"},

--- a/src/csv_upc_omg/barcode_lookup.py
+++ b/src/csv_upc_omg/barcode_lookup.py
@@ -1,0 +1,110 @@
+"""Utilities for fetching product information from barcode lookup services."""
+
+import httpx
+from bs4 import BeautifulSoup
+
+
+class BarcodeAPIError(Exception):
+    """Exception raised when barcode lookup fails."""
+
+
+async def fetch_product_title(upc: str, timeout: float = 10.0) -> str | None:
+    """Fetch product title from barcodelookup.com.
+
+    Args:
+        upc: The UPC code to lookup
+        timeout: Request timeout in seconds
+
+    Returns:
+        Product title if found, None if not found
+
+    Raises:
+        BarcodeAPIError: If there's an error fetching or parsing the page
+    """
+    url = f"https://www.barcodelookup.com/{upc}"
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+
+            soup = BeautifulSoup(response.text, "html.parser")
+
+            # Look for product title in various possible locations
+            title_selectors = [
+                "h1.product-title",
+                "h1",
+                ".product-name",
+                ".title",
+                '[data-testid="product-title"]',
+            ]
+
+            for selector in title_selectors:
+                title_element = soup.select_one(selector)
+                if title_element:
+                    title = title_element.get_text(strip=True)
+                    if title and title.lower() not in ["not found", "error", ""]:
+                        return title
+
+            # If no title found in expected locations, return None
+            return None
+
+    except httpx.TimeoutException:
+        raise BarcodeAPIError(f"Timeout while fetching product for UPC {upc}")
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            return None
+        raise BarcodeAPIError(f"HTTP error {e.response.status_code} for UPC {upc}")
+    except Exception as e:
+        raise BarcodeAPIError(f"Error fetching product for UPC {upc}: {e}")
+
+
+def fetch_product_title_sync(upc: str, timeout: float = 10.0) -> str | None:
+    """Synchronous version of fetch_product_title.
+
+    Args:
+        upc: The UPC code to lookup
+        timeout: Request timeout in seconds
+
+    Returns:
+        Product title if found, None if not found
+
+    Raises:
+        BarcodeAPIError: If there's an error fetching or parsing the page
+    """
+    url = f"https://www.barcodelookup.com/{upc}"
+
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            response = client.get(url)
+            response.raise_for_status()
+
+            soup = BeautifulSoup(response.text, "html.parser")
+
+            # Look for product title in various possible locations
+            title_selectors = [
+                "h1.product-title",
+                "h1",
+                ".product-name",
+                ".title",
+                '[data-testid="product-title"]',
+            ]
+
+            for selector in title_selectors:
+                title_element = soup.select_one(selector)
+                if title_element:
+                    title = title_element.get_text(strip=True)
+                    if title and title.lower() not in ["not found", "error", ""]:
+                        return title
+
+            # If no title found in expected locations, return None
+            return None
+
+    except httpx.TimeoutException:
+        raise BarcodeAPIError(f"Timeout while fetching product for UPC {upc}")
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            return None
+        raise BarcodeAPIError(f"HTTP error {e.response.status_code} for UPC {upc}")
+    except Exception as e:
+        raise BarcodeAPIError(f"Error fetching product for UPC {upc}: {e}")

--- a/src/csv_upc_omg/main.py
+++ b/src/csv_upc_omg/main.py
@@ -2,6 +2,7 @@
 
 import click
 
+from .barcode_lookup import BarcodeAPIError, fetch_product_title_sync
 from .csv_utils import extract_upcs_from_csv, find_most_recent_csv
 
 
@@ -36,6 +37,55 @@ def upcs(directory: str, verbose: bool) -> None:
 
         for upc in upc_list:
             click.echo(upc)
+
+    except (FileNotFoundError, NotADirectoryError) as e:
+        click.echo(f"Error: {e}", err=True)
+        raise click.Abort()
+    except Exception as e:
+        click.echo(f"Error processing CSV: {e}", err=True)
+        raise click.Abort()
+
+
+@cli.command()
+@click.argument(
+    "directory", type=click.Path(exists=True, file_okay=False, dir_okay=True)
+)
+@click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
+@click.option("--timeout", default=10.0, help="Request timeout in seconds", type=float)
+def titles(directory: str, verbose: bool, timeout: float) -> None:
+    """Extract UPCs from CSV and fetch product titles from barcodelookup.com."""
+    try:
+        csv_path = find_most_recent_csv(directory)
+
+        if csv_path is None:
+            click.echo("No CSV files found in the specified directory.")
+            return
+
+        if verbose:
+            click.echo(f"Processing most recent CSV: {csv_path}")
+
+        upc_list = extract_upcs_from_csv(csv_path)
+
+        if not upc_list:
+            click.echo("No UPCs found in the CSV file.")
+            return
+
+        if verbose:
+            click.echo(f"Found {len(upc_list)} UPCs, fetching product titles...")
+
+        for upc in upc_list:
+            try:
+                title = fetch_product_title_sync(upc, timeout=timeout)
+                if title:
+                    click.echo(f"{upc}: {title}")
+                else:
+                    click.echo(f"{upc}: Product not found")
+
+            except BarcodeAPIError as e:
+                if verbose:
+                    click.echo(f"{upc}: Error - {e}", err=True)
+                else:
+                    click.echo(f"{upc}: Lookup failed")
 
     except (FileNotFoundError, NotADirectoryError) as e:
         click.echo(f"Error: {e}", err=True)

--- a/tests/test_barcode_lookup.py
+++ b/tests/test_barcode_lookup.py
@@ -1,0 +1,191 @@
+"""Tests for the barcode_lookup module."""
+
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+
+from csv_upc_omg.barcode_lookup import (
+    BarcodeAPIError,
+    fetch_product_title_sync,
+)
+
+
+@patch("csv_upc_omg.barcode_lookup.httpx.Client")
+def test_fetch_product_title_sync_success(mock_client_class):
+    """Test successful product title fetch."""
+    mock_response = Mock()
+    mock_response.text = """
+    <html>
+        <body>
+            <h1 class="product-title">Test Product Name</h1>
+        </body>
+    </html>
+    """
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = Mock()
+    mock_client.get.return_value = mock_response
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    result = fetch_product_title_sync("123456789012")
+    assert result == "Test Product Name"
+    mock_client.get.assert_called_once_with(
+        "https://www.barcodelookup.com/123456789012"
+    )
+
+
+@patch("csv_upc_omg.barcode_lookup.httpx.Client")
+def test_fetch_product_title_sync_h1_fallback(mock_client_class):
+    """Test product title fetch with h1 fallback."""
+    mock_response = Mock()
+    mock_response.text = """
+    <html>
+        <body>
+            <h1>Generic Product Title</h1>
+        </body>
+    </html>
+    """
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = Mock()
+    mock_client.get.return_value = mock_response
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    result = fetch_product_title_sync("123456789012")
+    assert result == "Generic Product Title"
+
+
+@patch("csv_upc_omg.barcode_lookup.httpx.Client")
+def test_fetch_product_title_sync_no_title_found(mock_client_class):
+    """Test when no product title is found."""
+    mock_response = Mock()
+    mock_response.text = """
+    <html>
+        <body>
+            <p>No product information available</p>
+        </body>
+    </html>
+    """
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = Mock()
+    mock_client.get.return_value = mock_response
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    result = fetch_product_title_sync("123456789012")
+    assert result is None
+
+
+@patch("csv_upc_omg.barcode_lookup.httpx.Client")
+def test_fetch_product_title_sync_404_error(mock_client_class):
+    """Test handling of 404 errors."""
+    mock_response = Mock()
+    mock_response.status_code = 404
+
+    mock_client = Mock()
+    mock_client.get.side_effect = httpx.HTTPStatusError(
+        "404 Not Found", request=Mock(), response=mock_response
+    )
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    result = fetch_product_title_sync("123456789012")
+    assert result is None
+
+
+@patch("csv_upc_omg.barcode_lookup.httpx.Client")
+def test_fetch_product_title_sync_http_error(mock_client_class):
+    """Test handling of HTTP errors other than 404."""
+    mock_response = Mock()
+    mock_response.status_code = 500
+
+    mock_client = Mock()
+    mock_client.get.side_effect = httpx.HTTPStatusError(
+        "500 Server Error", request=Mock(), response=mock_response
+    )
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    with pytest.raises(BarcodeAPIError, match="HTTP error 500"):
+        fetch_product_title_sync("123456789012")
+
+
+@patch("csv_upc_omg.barcode_lookup.httpx.Client")
+def test_fetch_product_title_sync_timeout(mock_client_class):
+    """Test handling of timeout errors."""
+    mock_client = Mock()
+    mock_client.get.side_effect = httpx.TimeoutException("Timeout")
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    with pytest.raises(BarcodeAPIError, match="Timeout while fetching"):
+        fetch_product_title_sync("123456789012")
+
+
+@patch("csv_upc_omg.barcode_lookup.httpx.Client")
+def test_fetch_product_title_sync_generic_error(mock_client_class):
+    """Test handling of generic errors."""
+    mock_client = Mock()
+    mock_client.get.side_effect = Exception("Something went wrong")
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    with pytest.raises(BarcodeAPIError, match="Error fetching product"):
+        fetch_product_title_sync("123456789012")
+
+
+@patch("csv_upc_omg.barcode_lookup.httpx.Client")
+def test_fetch_product_title_sync_empty_title(mock_client_class):
+    """Test when title element exists but is empty."""
+    mock_response = Mock()
+    mock_response.text = """
+    <html>
+        <body>
+            <h1 class="product-title"></h1>
+        </body>
+    </html>
+    """
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = Mock()
+    mock_client.get.return_value = mock_response
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    result = fetch_product_title_sync("123456789012")
+    assert result is None
+
+
+@patch("csv_upc_omg.barcode_lookup.httpx.Client")
+def test_fetch_product_title_sync_not_found_title(mock_client_class):
+    """Test when title contains 'not found'."""
+    mock_response = Mock()
+    mock_response.text = """
+    <html>
+        <body>
+            <h1>Not Found</h1>
+        </body>
+    </html>
+    """
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = Mock()
+    mock_client.get.return_value = mock_response
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    result = fetch_product_title_sync("123456789012")
+    assert result is None
+
+
+@patch("csv_upc_omg.barcode_lookup.httpx.Client")
+def test_fetch_product_title_sync_custom_timeout(mock_client_class):
+    """Test custom timeout parameter."""
+    mock_response = Mock()
+    mock_response.text = "<html><body><h1>Test Product</h1></body></html>"
+    mock_response.raise_for_status.return_value = None
+
+    mock_client = Mock()
+    mock_client.get.return_value = mock_response
+    mock_client_class.return_value.__enter__.return_value = mock_client
+
+    result = fetch_product_title_sync("123456789012", timeout=5.0)
+    assert result == "Test Product"
+
+    # Verify timeout was passed to client
+    mock_client_class.assert_called_once_with(timeout=5.0)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@
 
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
@@ -69,3 +70,105 @@ def test_upcs_command_verbose() -> None:
         assert result.exit_code == 0
         assert "Processing most recent CSV" in result.output
         assert "123456789012" in result.output
+
+
+def test_titles_command_no_csv_files() -> None:
+    """Test titles command with directory containing no CSV files."""
+    runner = CliRunner()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        result = runner.invoke(cli, ["titles", temp_dir])
+
+        assert result.exit_code == 0
+        assert "No CSV files found" in result.output
+
+
+def test_titles_command_with_csv() -> None:
+    """Test titles command with CSV file."""
+    runner = CliRunner()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        csv_path = Path(temp_dir) / "test.csv"
+        csv_path.write_text("123456789012,Product A")
+
+        # Mock the barcode lookup function
+        with patch("csv_upc_omg.main.fetch_product_title_sync") as mock_fetch:
+            mock_fetch.return_value = "Test Product Title"
+
+            result = runner.invoke(cli, ["titles", temp_dir])
+
+            assert result.exit_code == 0
+            assert "123456789012: Test Product Title" in result.output
+            mock_fetch.assert_called_once_with("123456789012", timeout=10.0)
+
+
+def test_titles_command_product_not_found() -> None:
+    """Test titles command when product is not found."""
+    runner = CliRunner()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        csv_path = Path(temp_dir) / "test.csv"
+        csv_path.write_text("123456789012,Product A")
+
+        with patch("csv_upc_omg.main.fetch_product_title_sync") as mock_fetch:
+            mock_fetch.return_value = None
+
+            result = runner.invoke(cli, ["titles", temp_dir])
+
+            assert result.exit_code == 0
+            assert "123456789012: Product not found" in result.output
+
+
+def test_titles_command_api_error() -> None:
+    """Test titles command when API error occurs."""
+    runner = CliRunner()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        csv_path = Path(temp_dir) / "test.csv"
+        csv_path.write_text("123456789012,Product A")
+
+        with patch("csv_upc_omg.main.fetch_product_title_sync") as mock_fetch:
+            from csv_upc_omg.barcode_lookup import BarcodeAPIError
+
+            mock_fetch.side_effect = BarcodeAPIError("API Error")
+
+            result = runner.invoke(cli, ["titles", temp_dir])
+
+            assert result.exit_code == 0
+            assert "123456789012: Lookup failed" in result.output
+
+
+def test_titles_command_verbose() -> None:
+    """Test titles command with verbose flag."""
+    runner = CliRunner()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        csv_path = Path(temp_dir) / "test.csv"
+        csv_path.write_text("123456789012,Product A")
+
+        with patch("csv_upc_omg.main.fetch_product_title_sync") as mock_fetch:
+            mock_fetch.return_value = "Test Product Title"
+
+            result = runner.invoke(cli, ["titles", temp_dir, "--verbose"])
+
+            assert result.exit_code == 0
+            assert "Processing most recent CSV" in result.output
+            assert "Found 1 UPCs, fetching product titles" in result.output
+            assert "123456789012: Test Product Title" in result.output
+
+
+def test_titles_command_custom_timeout() -> None:
+    """Test titles command with custom timeout."""
+    runner = CliRunner()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        csv_path = Path(temp_dir) / "test.csv"
+        csv_path.write_text("123456789012,Product A")
+
+        with patch("csv_upc_omg.main.fetch_product_title_sync") as mock_fetch:
+            mock_fetch.return_value = "Test Product Title"
+
+            result = runner.invoke(cli, ["titles", temp_dir, "--timeout", "5.0"])
+
+            assert result.exit_code == 0
+            mock_fetch.assert_called_once_with("123456789012", timeout=5.0)

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,42 @@ revision = 2
 requires-python = ">=3.11"
 
 [[package]]
+name = "anyio"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916, upload-time = "2025-03-17T00:02:52.713Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/e4/0c4c39e18fd76d6a628d4dd8da40543d136ce2d1752bd6eeeab0791f4d6b/beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195", size = 621067, upload-time = "2025-04-15T17:05:13.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/cd/30110dc0ffcf3b131156077b90e9f60ed75711223f306da4db08eff8403b/beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b", size = 187285, upload-time = "2025-04-15T17:05:12.221Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2025.4.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6", size = 160705, upload-time = "2025-04-26T02:12:29.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3", size = 159618, upload-time = "2025-04-26T02:12:27.662Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -87,7 +123,9 @@ name = "csv-upc-omg"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "beautifulsoup4" },
     { name = "click" },
+    { name = "httpx" },
 ]
 
 [package.optional-dependencies]
@@ -108,7 +146,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.13.4" },
     { name = "click", specifier = ">=8.0.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
@@ -122,6 +162,52 @@ dev = [
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "ruff", specifier = ">=0.11.12" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
 ]
 
 [[package]]
@@ -262,6 +348,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/9b/c9ddf7f924d5617a1c94a93ba595f4b24cb5bc50e98b94433ab3f7ad27e5/ruff-0.11.12-py3-none-win32.whl", hash = "sha256:f5a07f49767c4be4772d161bfc049c1f242db0cfe1bd976e0f0886732a4765d6", size = 10475511, upload-time = "2025-05-29T13:31:32.917Z" },
     { url = "https://files.pythonhosted.org/packages/fd/d6/74fb6d3470c1aada019ffff33c0f9210af746cca0a4de19a1f10ce54968a/ruff-0.11.12-py3-none-win_amd64.whl", hash = "sha256:5a4d9f8030d8c3a45df201d7fb3ed38d0219bccd7955268e863ee4a115fa0832", size = 11523573, upload-time = "2025-05-29T13:31:35.782Z" },
     { url = "https://files.pythonhosted.org/packages/44/42/d58086ec20f52d2b0140752ae54b355ea2be2ed46f914231136dd1effcc7/ruff-0.11.12-py3-none-win_arm64.whl", hash = "sha256:65194e37853158d368e333ba282217941029a28ea90913c67e558c611d04daa5", size = 10697770, upload-time = "2025-05-29T13:31:38.009Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/f4/4a80cd6ef364b2e8b65b15816a843c0980f7a5a2b4dc701fc574952aa19f/soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a", size = 103418, upload-time = "2025-04-20T18:50:08.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/9c/0e6afc12c269578be5c0c1c9f4b49a8d32770a080260c333ac04cc1c832d/soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4", size = 36677, upload-time = "2025-04-20T18:50:07.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
• Add new `titles` command that fetches product titles from barcodelookup.com
• Extends existing UPC extraction functionality with web scraping capabilities
• Includes robust error handling, timeout configuration, and comprehensive testing

## Key Features
• **New CLI Command**: `csv-upc-omg titles <directory>` - extracts UPCs and fetches product titles
• **Web Scraping**: Uses httpx and BeautifulSoup4 to parse product information from barcodelookup.com
• **Error Handling**: Graceful handling of network timeouts, HTTP errors, and missing products
• **Configurable Timeout**: `--timeout` option to customize request timeouts (default: 10s)
• **Verbose Mode**: `--verbose` flag for detailed operation logging

## Implementation Details
• Added `barcode_lookup.py` module with both sync and async API support
• Comprehensive test suite with 31 passing tests including mocked HTTP requests
• Follows existing code patterns and maintains backward compatibility
• Uses multiple CSS selectors to reliably extract product titles

## Usage Examples
```bash
# Basic usage
csv-upc-omg titles /path/to/csv/directory

# With verbose output and custom timeout
csv-upc-omg titles /path/to/csv/directory --verbose --timeout 5.0
```

## Test Plan
- [x] All 31 tests pass (10 new barcode lookup tests, 6 new CLI tests)
- [x] Ruff linting and formatting checks pass
- [x] MyPy type checking passes
- [x] Backward compatibility maintained (existing `upcs` command unchanged)
- [x] Error handling tested for various HTTP scenarios