### PR TITLE
Add pre-commit hooks for automated code quality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-requests, types-beautifulsoup4]
+        args: [--config-file=pyproject.toml]
+        files: ^src/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ uv pip install -e .
 For development:
 
 ```bash
-uv pip install -e ".[dev]"
+uv sync --all-extras
+```
+
+Set up pre-commit hooks (recommended):
+
+```bash
+uv run pre-commit install
 ```
 
 ## Usage
@@ -27,20 +33,26 @@ csv-upc-omg --help
 Run tests:
 
 ```bash
-pytest
+uv run pytest
 ```
 
 Format and lint code:
 
 ```bash
-ruff format .
-ruff check .
+uv run ruff format .
+uv run ruff check .
 ```
 
 Type checking:
 
 ```bash
-mypy src/
+uv run mypy src/
+```
+
+Run all quality checks:
+
+```bash
+uv run pre-commit run --all-files
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "ruff>=0.1.0",
     "mypy>=1.0.0",
+    "pre-commit>=3.0.0",
 ]
 
 [build-system]
@@ -56,6 +57,11 @@ python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/test_hook.py
+++ b/test_hook.py
@@ -1,3 +1,0 @@
-def bad_function():
-    x = 1 + 2  # Bad formatting
-    return x

--- a/test_hook.py
+++ b/test_hook.py
@@ -1,0 +1,3 @@
+def bad_function():
+    x = 1 + 2  # Bad formatting
+    return x


### PR DESCRIPTION
## Summary
• Add comprehensive pre-commit hooks to enforce code quality standards automatically
• Configure ruff for linting and formatting, mypy for type checking, and basic file hygiene
• Update development documentation with setup instructions

## Changes
- **Pre-commit configuration**: Added `.pre-commit-config.yaml` with hooks for:
  - Basic file hygiene (trailing whitespace, end-of-file, YAML validation)
  - Ruff linting with auto-fix and formatting
  - MyPy type checking for `src/` directory only
- **Dependencies**: Added `pre-commit>=3.0.0` to dev dependencies
- **MyPy configuration**: Enhanced with missing import handling and relaxed test requirements
- **Documentation**: Updated README with pre-commit setup and usage instructions

## Test plan
- [x] Verify all hooks pass on existing codebase
- [x] Test hook enforcement by attempting commit with poorly formatted code
- [x] Confirm automatic formatting and linting corrections
- [x] Validate mypy type checking works correctly
- [x] Test development workflow with new commands